### PR TITLE
Update hass.h - add missing  "hass_init_textField_info()" to avoid br…

### DIFF
--- a/src/httpserver/hass.h
+++ b/src/httpserver/hass.h
@@ -145,5 +145,6 @@ HassDeviceInfo* hass_createToggle(const char *label, const char *stateTopic, con
 const char* hass_build_discovery_json(HassDeviceInfo* info);
 void hass_free_device_info(HassDeviceInfo* info); 
 char *hass_generate_multiplyAndRound_template(int decimalPlacesForRounding, int decimalPointOffset, int divider);
+HassDeviceInfo* hass_init_textField_info(int index);
 
 #endif // ENABLE_HA_DISCOVERY


### PR DESCRIPTION
…eaking ESP builds

ESP builds with "-Werror=implicit-function-declaration", so we get

 error: implicit declaration of function 'hass_init_textField_info';